### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "eriktorsner/wp-checksum",
     "description": "Check plugin and theme consistency",
     "homepage": "https://github.com/eriktorsner/wp-checksum/",
-    "type": "library",
+    "type": "wp-cli-package",
     "keywords": [
         "wordpress"
     ],


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
